### PR TITLE
Add the missing license input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,8 @@ inputs:
   approval-notes:
     description: A secret text to Mozilla reviewers.
     required: false
+  license:
+    description: Addon's license slug.
 
 runs:
   using: node20


### PR DESCRIPTION
Add `license` input in the action configuration.

![image](https://github.com/user-attachments/assets/512b5e92-71c3-4dbd-a5df-3bd92706d63f)
